### PR TITLE
don't force user to set openrc_os_domain_name

### DIFF
--- a/templates/openrc.j2
+++ b/templates/openrc.j2
@@ -16,8 +16,10 @@ export OS_PROJECT_NAME={{ openrc_os_tenant_name }}
 export OS_TENANT_NAME={{ openrc_os_tenant_name }}
 export OS_AUTH_URL={{ openrc_os_auth_url }}
 export OS_NO_CACHE=1
+{% if openrc_os_domain_name is defined %}
 export OS_USER_DOMAIN_NAME={{ openrc_os_domain_name }}
 export OS_PROJECT_DOMAIN_NAME={{ openrc_os_domain_name }}
+{% endif %}
 export OS_REGION_NAME={{ openrc_region_name }}
 
 # For openstackclient


### PR DESCRIPTION
PR to discuss.
When not defined (unknown by the user or not specified by the provider), they need to stay unset rather than set to an empty value.